### PR TITLE
Add Multi AZ Support

### DIFF
--- a/network/subnet/inputs.tf
+++ b/network/subnet/inputs.tf
@@ -22,9 +22,12 @@ variable "sub_tags" {
     default = {}
 }
 variable "sub_azs" {
-    type = "list"
+    description = "A list of AZs"
+    type        = list(string)
     default = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
 }
 variable "subnets" {
-    type = "list"
+    description = "A list of subnets"
+    type        = list(string)
+    default     = []
 }

--- a/network/subnet/outputs.tf
+++ b/network/subnet/outputs.tf
@@ -1,10 +1,10 @@
 output "sub_id" {
-    value = "${aws_subnet.this[count.index].id}"
+    value = "${aws_subnet.this.*.id}"
     description = "Subnet ID"
 }
 
 output "sub_arn" {
-    value = "${aws_subnet.*.id[count.index]}"
+    value = "${aws_subnet.this.*.id}"
     description = "Subnet ARN"
 }
 

--- a/network/vpc/inputs.tf
+++ b/network/vpc/inputs.tf
@@ -23,10 +23,10 @@ variable "vpc_secondary_cidr" {
     default = "10.61.0.0/24"
 }
 variable "vpc_primary_az" {
-    default = "euw2-az1"
+    default = ["eu-west-2a"]
 }
 variable "vpc_secondary_az" {
-    default = "euw2-az2"
+    default = ["eu-west-2a"]
 }
 variable "vpc_tags" {
     type = "map"


### PR DESCRIPTION
Multi AZ Suport was needed for the deployment architecture

* Adds support for multi AZ deployments for each "subnet group"
* Upgraded to Terraform 0.12
* Currently only supports eu-west-2 in defaults